### PR TITLE
fix: pin numpy version in rembg-image-processor

### DIFF
--- a/packages/middlewares/image-processors/rembg-image-processor/src/lambdas/processor/requirements.txt
+++ b/packages/middlewares/image-processors/rembg-image-processor/src/lambdas/processor/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.37.11
 aws_lambda_powertools==2.36.0
 aws-xray-sdk==2.13.0
 rembg==2.0.64
+numpy==1.24.4


### PR DESCRIPTION
## Summary
- Pin numpy to version 1.24.4 in rembg-image-processor requirements
- Ensures consistent dependency resolution with rembg 2.0.64
- Prevents potential compatibility issues in Lambda runtime

## Test plan
- [ ] Verify rembg-image-processor builds successfully
- [ ] Confirm Lambda function deploys without dependency conflicts
- [ ] Test image background removal functionality works as expected